### PR TITLE
[FEAT] GlobalException, SuccessResponse, BaseEntity

### DIFF
--- a/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/exception/ErrorCode.java
+++ b/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/exception/ErrorCode.java
@@ -1,0 +1,37 @@
+package com.sparta.logistics.hub.libs.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // global
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    NOT_AUTHENTICATED_USER(HttpStatus.UNAUTHORIZED, "인증된 사용자가 아닙니다."),
+    UNEXPECTED_PRINCIPAL_TYPE(HttpStatus.BAD_REQUEST, "예상치 못한 Principal 타입입니다."),
+
+
+    // domain
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 허브를 찾을 수 없습니다."),
+
+
+    /**
+     * 사용 예
+     * **CUSTOM_NAME**(HttpStatus.**ENUM_NAME**,"**MESSAGE**"),
+     * 위 코드를 작성하고
+     * throw new GlobalException(**CUSTOM_NAME**));
+     * 위 코드와 같이 throw 요청시 처리됩니다.
+     *
+     * ex) HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 허브를 찾을 수 없습니다.")
+     * ex) throw new GlobalException(HUB_NOT_FOUND)
+     */
+
+    ;
+    private final HttpStatus httpStatus;
+    private final String description;
+}

--- a/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/exception/GlobalException.java
+++ b/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/exception/GlobalException.java
@@ -1,0 +1,11 @@
+package com.sparta.logistics.hub.libs.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GlobalException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/exception/GlobalExceptionHandler.java
+++ b/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/exception/GlobalExceptionHandler.java
@@ -1,0 +1,127 @@
+package com.sparta.logistics.hub.libs.exception;
+
+import static com.sparta.logistics.hub.libs.exception.ErrorCode.BAD_REQUEST;
+import static com.sparta.logistics.hub.libs.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+
+import com.sparta.logistics.hub.libs.model.ErrorResponse;
+import com.sparta.logistics.hub.libs.model.ErrorResponse.ValidationError;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * GlobalException(커스텀 에러) 처리
+     *
+     * @param e GlobalException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<Object> handleCustomException(GlobalException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("GlobalException occurred : ErrorCode = {} message = {}",
+                  errorCode.name(), errorCode.getDescription());
+        return handleExceptionInternal(errorCode);
+    }
+
+    /**
+     * MethodArgumentNotValidException 처리 (Validation 실패 등)
+     *
+     * @param e MethodArgumentNotValidException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new HashMap<>();
+
+        // 모든 유효성 검증 오류를 가져와서 메시지를 구성
+        for (FieldError error : e.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
+    /**
+     * IllegalArgumentException 처리 (적절하지 않은 파라미터)
+     *
+     * @param e IllegalArgumentException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
+        log.error("IllegalArgumentException occurred", e);
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    /**
+     * DataIntegrityViolationException 처리 (DB 제약 조건 위반)
+     *
+     * @param e DataIntegrityViolationException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        log.error("DataIntegrityViolationException occurred", e);
+        return handleExceptionInternal(BAD_REQUEST);
+    }
+
+    /**
+     * Exception 처리
+     *
+     * @param e Exception
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleException(Exception e) {
+        log.error("Unexpected Exception occurred", e);
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(INTERNAL_SERVER_ERROR.getDescription());
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponseBody(errorCode));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponseBody((MethodArgumentNotValidException) e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponseBody(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .build();
+    }
+
+    private ErrorResponse makeErrorResponseBody(BindException e, ErrorCode errorCode) {
+        List<ValidationError> validationErrorList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .errors(validationErrorList)
+                .build();
+    }
+
+}

--- a/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/model/BaseEntity.java
+++ b/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/model/BaseEntity.java
@@ -1,0 +1,48 @@
+package com.sparta.logistics.hub.libs.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(length = 100, updatable = false)
+    private String createdBy;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(length = 100)
+    private String updatedBy;
+
+    private LocalDateTime deletedAt;
+
+    @Column(length = 100)
+    private String deletedBy;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    public void setDelete(LocalDateTime deletedAt, String deletedBy) {
+        this.deletedAt = deletedAt;
+        this.deletedBy = deletedBy;
+        this.isDeleted = true;
+    }
+
+}

--- a/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/model/ErrorResponse.java
+++ b/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/model/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.sparta.logistics.hub.libs.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.validation.FieldError;
+
+@Builder
+public record ErrorResponse(
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ValidationError> errors
+) {
+
+    @Builder
+    public record ValidationError(
+            String field,
+            String message
+    ) {
+
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/model/ResponseMessage.java
+++ b/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/model/ResponseMessage.java
@@ -1,0 +1,27 @@
+package com.sparta.logistics.hub.libs.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage{
+
+    // global
+
+    /**
+     * 사용 예
+     * **CUSTOM_NAME**("**MESSAGE**"), 등록 후
+     *
+     * Controller 또는 Service단 에서 응답 데이터 예시
+     * return ResponseEntity.ok().body(
+     *      SuccessResponse.of(**CUSTOM_NAME**, CUSTOM_RESPONSE_DTO) // 여기서 CUSTOM_RESPONSE_DTO는 해당 도메인에서 응답에 담는 데이터DTO 입니다.
+     * )
+     */
+
+    // domain
+    HUB_CREATE_SUCCESS("허브 등록 성공"),
+
+    ;
+    private final String message;
+}

--- a/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/model/SuccessResponse.java
+++ b/com.sparta.logistics.hub/src/main/java/com/sparta/logistics/hub/libs/model/SuccessResponse.java
@@ -1,0 +1,42 @@
+package com.sparta.logistics.hub.libs.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+public record SuccessResponse<T>(
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL) T data
+) {
+
+    public static <T> SuccessResponse<T> of(ResponseMessage message, T data) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message(message.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(ResponseMessage message) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message(message.getMessage())
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(T data) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message("")
+                .data(data)
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(String code, ResponseMessage message) {
+        return SuccessResponse.<T>builder()
+                .code(code)
+                .message(message.getMessage())
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #3 #4 #5 

## 📝작업 내용

> #### #3 GlobalException 
> 요약
> ![스크린샷 2024-12-11 155609](https://github.com/user-attachments/assets/db997785-5739-48ca-aeb6-9d10c98f41dd)

> #### #4 SuccessResponse
> 요약
> ![스크린샷 2024-12-11 155702](https://github.com/user-attachments/assets/063cd6e3-4034-457d-bb1d-227a3acdcbca)

> #### #5 BaseEntity
> 요약
> ![스크린샷 2024-12-11 155513](https://github.com/user-attachments/assets/2bf2f76f-1222-4f29-a412-2bac93dfc9fa)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
> 각 공통 라이브러리 요소가 알맞게 작성 되었는지 리뷰 부탁드립니다.
