### PR TITLE
[FEAT] 배송 경로 생성 후 사용자에게 알림 정보 보내는 기능 구현

### DIFF
--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/dto/delivery/CreateDeliveryRequest.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/dto/delivery/CreateDeliveryRequest.java
@@ -21,6 +21,7 @@ public class CreateDeliveryRequest {
   private String deliveryMainAddress;
   private String deliveryDetailAddress;
   private String recipientName;
+  private String slackId;
 
   public static CreateDeliveryRequest of(
       OrderResponseDto orderResponseDto,
@@ -35,6 +36,7 @@ public class CreateDeliveryRequest {
         .deliveryMainAddress(receiverCompany.getCompanyMainAddress())
         .deliveryDetailAddress(receiverCompany.getCompanyDetailAddress())
         .recipientName(receiverCompany.getCompanyName())
+        .slackId(slackId)
         .build();
   }
 
@@ -47,6 +49,7 @@ public class CreateDeliveryRequest {
         .deliveryMainAddress(this.deliveryMainAddress)
         .deliveryDetailAddress(this.deliveryDetailAddress)
         .recipientName(this.recipientName)
+        .slackId(this.slackId)
         .build();
   }
 }

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/dto/delivery/CreateDeliveryRequest.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/dto/delivery/CreateDeliveryRequest.java
@@ -26,8 +26,8 @@ public class CreateDeliveryRequest {
   public static CreateDeliveryRequest of(
       OrderResponseDto orderResponseDto,
       CompanyClientResponse receiverCompany,
-      CompanyClientResponse supplierCompany
-  ) {
+      CompanyClientResponse supplierCompany,
+      String slackId) {
     return CreateDeliveryRequest.builder()
         .orderId(orderResponseDto.getOrderId())
         .status(DeliveryStatus.PENDING)

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/service/DeliveryService.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/service/DeliveryService.java
@@ -35,10 +35,15 @@ public class DeliveryService {
 
   private final DeliveryRepository deliveryRepository;
   private final CompanyServiceClient companyServiceClient;
+  private final UserServiceClient userServiceClient;
   private final DeliveryValidation deliveryValidation;
+  private final UserContextHolder userContextHolder;
 
   @Transactional
   public CreateDeliveryResponse createDelivery(OrderResponseDto orderResponseDto) {
+
+    String username = userContextHolder.getCurrentAuditor();
+    String slackId = String.valueOf(userServiceClient.getUserByUsername(username));
 
     // 1. 수령 업체 정보 조회
     CompanyClientResponse receiverCompany = companyServiceClient.getCompany(
@@ -53,7 +58,8 @@ public class DeliveryService {
     CreateDeliveryRequest request = CreateDeliveryRequest.of(
         orderResponseDto,
         receiverCompany,
-        supplierCompany
+        supplierCompany,
+        slackId
     );
 
     deliveryValidation.createDeliveryValidation(request);

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/service/DeliveryService.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/service/DeliveryService.java
@@ -10,12 +10,17 @@ import com.sparta.logistics.delivery.domain.model.DeliveryStatus;
 import com.sparta.logistics.delivery.domain.repository.delivery.DeliveryRepository;
 import com.sparta.logistics.delivery.infrastructure.client.company.CompanyServiceClient;
 import com.sparta.logistics.delivery.infrastructure.client.company.CompanyClientResponse;
+import com.sparta.logistics.delivery.infrastructure.client.notification.NotificationRequest;
+import com.sparta.logistics.delivery.infrastructure.client.notification.NotificationServiceClient;
 import com.sparta.logistics.delivery.infrastructure.client.order.OrderResponseDto;
+import com.sparta.logistics.delivery.infrastructure.client.user.UserServiceClient;
+import com.sparta.logistics.delivery.infrastructure.configuration.UserContextHolder;
 import com.sparta.logistics.delivery.libs.exception.ErrorCode;
 import com.sparta.logistics.delivery.libs.exception.GlobalException;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +60,6 @@ public class DeliveryService {
 
     Delivery delivery = request.toEntity();
     delivery = deliveryRepository.save(delivery);
-
     return CreateDeliveryResponse.fromEntity(delivery);
   }
 

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/service/TransferRouteService.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/application/service/TransferRouteService.java
@@ -10,6 +10,8 @@ import com.sparta.logistics.delivery.domain.repository.transferroute.TransferRou
 import com.sparta.logistics.delivery.infrastructure.client.hub.HubTransferClient;
 import com.sparta.logistics.delivery.infrastructure.client.hub.HubTransferResponse;
 import com.sparta.logistics.delivery.infrastructure.client.hub.HubTransferRouteRequest;
+import com.sparta.logistics.delivery.infrastructure.client.notification.NotificationRequest;
+import com.sparta.logistics.delivery.infrastructure.client.notification.NotificationServiceClient;
 import com.sparta.logistics.delivery.libs.exception.ErrorCode;
 import com.sparta.logistics.delivery.libs.exception.GlobalException;
 import jakarta.transaction.Transactional;
@@ -28,6 +30,7 @@ public class TransferRouteService {
   private final DeliveryRepository deliveryRepository;
   private final DriverService driverService;
   private final HubTransferClient hubTransferClient;
+  private final NotificationServiceClient notificationServiceClient;
 
   @Transactional
   public TransferRouteResponse createTransferRoute(CreateTransferRouteRequest request) {
@@ -56,7 +59,32 @@ public class TransferRouteService {
         Objects.requireNonNull(hubResponse.getBody())
     );
 
+    sendTransferRouteNotification(transferRoute, delivery, driver);
+
     return TransferRouteResponse.fromEntity(transferRouteRepository.save(transferRoute));
   }
 
+  private void sendTransferRouteNotification(TransferRoute transferRoute, Delivery delivery, Driver driver) {
+    String message = String.format("""
+            주문 번호 : %s
+            배송 경로 순서 : %d
+            출발 허브 : %s
+            도착 허브 : %s
+            예상 이동 거리 : %dkm
+            예상 소요 시간 : %d분
+            배송담당자 : %s
+            """,
+        delivery.getOrderId(),
+        transferRoute.getSequence(),
+        transferRoute.getFromHubId(),  // 필요시 Hub 서비스에서 이름 조회
+        transferRoute.getToHubId(),    // 필요시 Hub 서비스에서 이름 조회
+        transferRoute.getExpectedDistance(),
+        transferRoute.getExpectedDuration(),
+        driver.getUsername()
+    );
+
+    notificationServiceClient.sendNotification(
+        new NotificationRequest(delivery.getSlackId(), message)
+    );
+  }
 }

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/infrastructure/client/notification/NotificationRequest.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/infrastructure/client/notification/NotificationRequest.java
@@ -1,0 +1,13 @@
+package com.sparta.logistics.delivery.infrastructure.client.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationRequest {
+
+  private String recipientId;  // slackId
+  private String message;
+
+}

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/infrastructure/client/notification/NotificationServiceClient.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/infrastructure/client/notification/NotificationServiceClient.java
@@ -1,0 +1,14 @@
+package com.sparta.logistics.delivery.infrastructure.client.notification;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "notification-service")
+public class NotificationServiceClient {
+
+  @PostMapping("/notifications/slack/send")
+  public void sendNotification(@RequestBody NotificationRequest request) {
+
+  }
+}

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/infrastructure/client/user/UserResponse.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/infrastructure/client/user/UserResponse.java
@@ -1,0 +1,12 @@
+package com.sparta.logistics.delivery.infrastructure.client.user;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponse {
+
+  private String username;
+  private String slackId;
+}

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/infrastructure/client/user/UserServiceClient.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/infrastructure/client/user/UserServiceClient.java
@@ -1,0 +1,13 @@
+package com.sparta.logistics.delivery.infrastructure.client.user;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service")
+public interface UserServiceClient {
+
+  @GetMapping("/users/{username}")
+  ResponseEntity<UserResponse> getUserByUsername(@PathVariable String username);
+}

--- a/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/presentation/controller/DeliveryController.java
+++ b/com.sparta.logistics.delivery/src/main/java/com/sparta/logistics/delivery/presentation/controller/DeliveryController.java
@@ -36,6 +36,14 @@ public class DeliveryController {
     return ResponseEntity.ok(response);
   }
 
+  @PostMapping("/test")
+  public ResponseEntity<CreateDeliveryResponse> createDeliveryTest(
+      @RequestBody OrderResponseDto orderResponseDto
+  ) {
+    return ResponseEntity.ok(deliveryService.createDelivery(orderResponseDto));
+  }
+
+
   @PutMapping("/{deliveryId}")
   public ResponseEntity<GetDeliveryResponse> updateDelivery(
       @PathVariable UUID deliveryId,
@@ -65,5 +73,6 @@ public class DeliveryController {
   ) {
     return ResponseEntity.ok(deliveryService.findDeliveries(status));
   }
+
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

>  배송 생성시 사용자 헤더값으로 slackId 조회 해오도록 구현
>  배송 경로 생성시 notification service 에 알림 메세지 송신하도록 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
